### PR TITLE
Remove unused `AllowUnsafeBlocks`

### DIFF
--- a/src/ExceptionAnalyzer/ExceptionAnalyzer.csproj
+++ b/src/ExceptionAnalyzer/ExceptionAnalyzer.csproj
@@ -31,7 +31,6 @@
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There are no `unsafe` blocks in the code base
https://github.com/search?q=repo%3Aelmahio%2FExceptionator%20unsafe&type=code

"The AllowUnsafeBlocks compiler option allows code that uses the unsafe keyword to compile. The default value for this option is false, meaning unsafe code isn't allowed." https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/language#allowunsafeblocks